### PR TITLE
x2: removed 32 bit libcameraservice.so

### DIFF
--- a/x2/x2-vendor.mk
+++ b/x2/x2-vendor.mk
@@ -178,7 +178,6 @@ PRODUCT_COPY_FILES += \
     vendor/leeco/x2/proprietary/lib/libarcsoft_smart_denoise.so:system/lib/libarcsoft_smart_denoise.so \
     vendor/leeco/x2/proprietary/lib/libBD_asr_model_cmn-Hans-CN_v1_camera.so:system/lib/libBD_asr_model_cmn-Hans-CN_v1_camera.so \
     vendor/leeco/x2/proprietary/lib/libcamera_letv_algo.so:system/lib/libcamera_letv_algo.so \
-    vendor/leeco/x2/proprietary/lib/libcameraservice.so:system/lib/libcameraservice.so \
     vendor/leeco/x2/proprietary/lib/libentryexstd.so:system/lib/libentryexstd.so \
     vendor/leeco/x2/proprietary/lib/libextmedia_jni.so:system/lib/libextmedia_jni.so \
     vendor/leeco/x2/proprietary/lib/libjpush219.so:system/lib/libjpush219.so \


### PR DESCRIPTION
removed 32 bit libcameraservice.so from x2-vendor.mk

Change-Id: I132176c40f4d45449521eec319a41f98ec68521d